### PR TITLE
Changed output of nodes when the result set is empty.

### DIFF
--- a/nodes/find-group.html
+++ b/nodes/find-group.html
@@ -82,11 +82,21 @@
         <dd> the group name of the group we want to get information. It also works with DN.</dd>
       </dl>
       <dl class="message-properties">
-        <dt>tlsOptions
+        <dt>ad_attributes <i>(optional)</i>
+          <span class="property-type">JSON object</span>
+        </dt>
+        <dd> 
+          <p>The attributes we want to return for the found group. 
+            By default, if not set, the following attributes are returned:</p>
+          <p>distinguishedName, objectCategory, cn, description</p>
+        </dd>
+      </dl>
+        <dl class="message-properties">
+        <dt>tlsOptions <i>(optional)</i>
           <span class="property-type">JSON object</span>
         </dt>
         <dd>
-          <p><code>msg.tlsOptions</code>: (Optional) Additional options passed to TLS connection layer when connecting via <code>ldaps://</code>. (See: <a target="_blank" href="https://nodejs.org/api/tls.html#tls_tls_connect_options_callback">TLS docs for node.js</a>)</p>
+          <p>Additional options passed to TLS connection layer when connecting via <code>ldaps://</code>. (See: <a target="_blank" href="https://nodejs.org/api/tls.html#tls_tls_connect_options_callback">TLS docs for node.js</a>)</p>
         </dd>
       </dl>
   
@@ -95,8 +105,14 @@
            <li>Standard output
                <dl class="message-properties">
                    <dt>payload <span class="property-type">string</span></dt>
-                   <dd>the standard output of the command, a JSON object that contains all the information about the group.</dd>
+                   <dd>the standard output of the command, a JSON object that contains all the information about the group.
+                       If no group was found, the message has no <code>payload</code> attribute.
+                   </dd>
                </dl>
+              <dl class="message-properties">
+                   <dt>ad_error <i>(optional)</i><span class="property-type">string</span></dt>
+                   <dd>Contains an error message, if no group was found.</dd>
+              </dl>
            </li>
            <li>Standard error
                <dl class="message-properties">

--- a/nodes/find-group.js
+++ b/nodes/find-group.js
@@ -41,7 +41,7 @@ module.exports = function(RED) {
             node.error(errTxt, msg);
           } else if (! group) {
             let errTxt =  'Group ' + dn + ' not found.';
-            msg.payload = new Object();
+            delete msg.payload;
             msg.ad_error = errTxt;
             node.status({fill:"yellow", shape:"dot", text: errTxt});
             node.send(msg);

--- a/nodes/find-group.js
+++ b/nodes/find-group.js
@@ -36,21 +36,23 @@ module.exports = function(RED) {
         node.status({fill:"blue",shape:"ring",text:"querying"});
         ad.findGroup(dn, function(err, group) {
           if (err) {
-            node.status({fill:"red", shape:"dot", text:"error querying"});
-            node.error('ERROR querying: ' + JSON.stringify(err), msg);
-            return;
-          }
-          if (! group) {
-            node.status({fill:"red", shape:"dot", text:"group not found"});
-            node.error('Group: ' + dn + ' not found.', msg);
+            let errTxt = 'ERROR querying: ' + JSON.stringify(err);
+            node.status({fill:"red", shape:"dot", text: errTxt});
+            node.error(errTxt, msg);
+          } else if (! group) {
+            let errTxt =  'Group ' + dn + ' not found.';
+            msg.payload = new Object();
+            msg.ad_error = errTxt;
+            node.status({fill:"yellow", shape:"dot", text: errTxt});
+            node.send(msg);
           }else {
             msg.payload = group;
-            node.status({});
+            node.status({fill:"green", shape:"dot", text: 'Group ' + dn + ' found'});
             node.send(msg);
           }
         });
       } catch(e) {
-        node.status({fill:"red", shape:"dot", text:"connexion error"});
+        node.status({fill:"red", shape:"dot", text:"connection error"});
         node.error('ERROR connecting: ' + e.message, msg);
       }
     });

--- a/nodes/find-user.html
+++ b/nodes/find-user.html
@@ -82,11 +82,21 @@
       <dd> the AD username of the user we want to get information. It also works with DN.</dd>
     </dl>
     <dl class="message-properties">
-      <dt>tlsOptions
+      <dt>ad_attributes <i>(optional)</i>
+        <span class="property-type">JSON object</span>
+      </dt>
+      <dd> 
+        <p>The attributes we want to return for the found user. 
+          By default, if not set, the following attributes are returned:</p>
+        <p>distinguishedName, userPrincipalName, sAMAccountName, mail, lockoutTime, whenCreated, pwdLastSet, userAccountControl, employeeID, sn, givenName, initials, cn, displayName, comment, description</p>
+      </dd>
+    </dl>
+    <dl class="message-properties">
+      <dt>tlsOptions <i>(optional)</i>
         <span class="property-type">JSON object</span>
       </dt>
       <dd>
-        <p><code>msg.tlsOptions</code>: (Optional) Additional options passed to TLS connection layer when connecting via <code>ldaps://</code>. (See: <a target="_blank" href="https://nodejs.org/api/tls.html#tls_tls_connect_options_callback">TLS docs for node.js</a>)</p>
+        <p>Additional options passed to TLS connection layer when connecting via <code>ldaps://</code>. (See: <a target="_blank" href="https://nodejs.org/api/tls.html#tls_tls_connect_options_callback">TLS docs for node.js</a>)</p>
       </dd>
     </dl>
 
@@ -95,7 +105,13 @@
          <li>Standard output
              <dl class="message-properties">
                  <dt>payload <span class="property-type">string</span></dt>
-                 <dd>the standard output of the command, a JSON object that contains all the information about the user.</dd>
+                 <dd>the standard output of the command, a JSON object that contains all the information about the user.
+                     If no user was found, the message has no <code>payload</code> attribute.
+                 </dd>
+             </dl>
+             <dl class="message-properties">
+                 <dt>ad_error <i>(optional)</i><span class="property-type">string</span></dt>
+                 <dd>Contains an error message, if no user was found.</dd>
              </dl>
          </li>
          <li>Standard error

--- a/nodes/find-user.js
+++ b/nodes/find-user.js
@@ -41,7 +41,7 @@ module.exports = function(RED) {
             node.error(errTxt);
           } else if (! user) {
             var errTxt = "User " + dn + " not found";
-            msg.payload = new Object();
+            delete msg.payload;
             msg.ad_error = errTxt;
             node.status({fill:"yellow", shape:"dot", text: errTxt});
             node.send(msg);

--- a/nodes/query.html
+++ b/nodes/query.html
@@ -83,20 +83,20 @@
       <dd> <code>msg.payload</code>: an Active Directory query </dd>
     </dl>
     <dl class="message-properties">
-      <dt>ad_attributes
+      <dt>ad_attributes <i>(optional)</i>
         <span class="property-type">JSON object</span>
       </dt>
-      <dd> <p><code>msg.ad_attributes</code>: the attributes we want to return for users and groups. By default, if not set, the following attributes are returned for users and groups:</p>
+      <dd>The attributes we want to return for users and groups. By default, if not set, the following attributes are returned for users and groups:</p>
         <p><b>user</b> - distinguishedName, userPrincipalName, sAMAccountName, mail, lockoutTime, whenCreated, pwdLastSet, userAccountControl, employeeID, sn, givenName, initials, cn, displayName, comment, description</p>
         <p><b>group</b> - distinguishedName, objectCategory, cn, description</p>
       </dd>
     </dl>
     <dl class="message-properties">
-      <dt>tlsOptions
+      <dt>tlsOptions <i>(optional)</i>
         <span class="property-type">JSON object</span>
       </dt>
       <dd>
-        <p><code>msg.tlsOptions</code>: (Optional) Additional options passed to TLS connection layer when connecting via <code>ldaps://</code>. (See: <a target="_blank" href="https://nodejs.org/api/tls.html#tls_tls_connect_options_callback">TLS docs for node.js</a>)</p>
+        <p>Additional options passed to TLS connection layer when connecting via <code>ldaps://</code>. (See: <a target="_blank" href="https://nodejs.org/api/tls.html#tls_tls_connect_options_callback">TLS docs for node.js</a>)</p>
       </dd>
     </dl>
   </ol>

--- a/nodes/query.js
+++ b/nodes/query.js
@@ -42,14 +42,14 @@ module.exports = function(RED) {
           if (err) {
             node.status({fill:"red", shape:"dot", text:"error querying"});
             node.error('ERROR querying: ' + JSON.stringify(err), msg);
-            return;
-          }
-          msg.payload = results;
-          node.status({});
+          } else {
+            msg.payload = results;
+          node.status({fill:"green", shape:"dot", text:"query successful"});
           node.send(msg);
+          }
         });
       } catch(e) {
-        node.status({fill:"red", shape:"dot", text:"connexion error"});
+        node.status({fill:"red", shape:"dot", text:"connection error"});
         node.error('ERROR connecting: ' + e.message, msg);
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-activedirectory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Node-RED node collection for Microsoft Active Directory.",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     }
   },
   "dependencies": {
-    "activedirectory2": "^1.3.0"
+    "activedirectory2": "^2.1.0"
   },
   "devDependencies": {
     "express": "^4.16.2",


### PR DESCRIPTION
This PR solves #12 and adds some help messages as a first step to solve #7 .

- The nodes `find user`and `find group` will now only throw an error, when there is a _real_ LDAP error.
- If the result set of the query is empty, the payload will be `empty` an an attribute `ad_error`is added to the message.
- Some enhancements to the help sidebar of the nodes.